### PR TITLE
These patchs solves and infinite loop when sending mail

### DIFF
--- a/extsmaild.c
+++ b/extsmaild.c
@@ -1260,7 +1260,7 @@ bool set_nonblock(int fd)
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags == -1)
         return false;
-    if (fcntl(fd, F_SETFL, flags || O_NONBLOCK) == -1)
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
         return false;
     return true;
 }


### PR DESCRIPTION
Without checking for POLLHUP on client's stderr the test

```
while (!eof_fd || !eof_cstderr) {
```

would never fail, thus entering an infinite loop

That would at last fail because of the timeout
