### PR TITLE
make distclean removed too much files.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -49,24 +49,23 @@ install: all
 	install -c -m 444 extsmail.conf.5 \
 	  ${DESTDIR}${prefix}/man/man5/extsmail.conf.5
 	install -c -m 444 extsmail.externals.5 \
-      ${DESTDIR}${prefix}/man/man5/extsmail.externals.5
+	  ${DESTDIR}${prefix}/man/man5/extsmail.externals.5
 	install -c -m 444 extsmaild.1 ${DESTDIR}${prefix}/man/man1/extsmaild.1
 
 
 clean:
 	rm -f extsmail extsmaild ${EXTSMAIL_OBJS} ${EXTSMAILD_OBJS} \
 	  conf_parser.tab.[ch] externals_parser.tab.[ch] conf_tokenizer.c \
-	  externals_tokenizer.c ${MAN_PAGES}
+	  externals_tokenizer.c
 
 
 distclean: clean
-	rm -rf configure Makefile Config.h Config.h.in autom4te.cache config.log \
-	  config.status
+	rm -rf Makefile Config.h autom4te.cache config.log config.status
 
 
-distrib:
+dist:
 	${MAKE} distclean
 	${MAKE} -f Makefile.bootstrap
 	@read -p 'extsmail version: ' v; mkdir extsmail-$$v; \
-      cp -r `ls | grep -E -v "(autom4te.cache)|(Makefile.bootstrap)|(extsmail-$$v)"` extsmail-$$v; \
-      tar cfz extsmail-$$v.tar.gz extsmail-$$v; rm -rf extsmail-$$v
+	  cp -r `ls | grep -E -v "(autom4te.cache)|(Makefile.bootstrap)|(extsmail-$$v)"` extsmail-$$v; \
+	  tar cfz extsmail-$$v.tar.gz extsmail-$$v; rm -rf extsmail-$$v


### PR DESCRIPTION
I was dumb and landry@ confirmed, no need to use automake.
Debian packages are now OK with this modification, let's hope it doesn't break anything elsewhere :)
