### PR TITLE
Don't use GNU specific format specifier "%m"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,13 +43,6 @@ AC_GNU_SOURCE
 
 CFLAGS="$CFLAGS -std=c99 -Wall -pedantic -Wextra"
 
-# gcc (at least 4.9) emits
-#   "warning: ISO C does not support the ‘%m’ gnu_printf format"
-# clang does not
-if test "x${CC}" = "xgcc"; then
-	CFLAGS="$CFLAGS -Wno-format"
-fi
-
 # kqueue (*BSD)
 
 AH_TEMPLATE(HAVE_KQUEUE,


### PR DESCRIPTION
For portability reasons (and to avoid build failures like in [Debian Bug 871086](https://bugs.debian.org/871086)) it would be best to not use the %m format identifier. Thanks for considering the pull request.