### PR TITLE
Display program version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 
-AC_INIT([extsmail], EXTSMAIL_VERSION)
+AC_INIT([extsmail], [2.2])
 
 ################################################################################
 # Generic initialization

--- a/extsmaild.1
+++ b/extsmaild.1
@@ -27,6 +27,7 @@
 .Nm extsmaild
 .Op Fl m Ar mode
 .Op Fl t
+.Op Fl v
 .Sh DESCRIPTION
 .Nm
 sends messages spooled by
@@ -57,6 +58,10 @@ The
 flag can be specified to test the configuration files for
 .Nm
 without running the mail sending process.
+.Pp
+The
+.Fl v
+flag prints version info to stdout, then exits.
 .Sh SEE ALSO
 .Xr extsmail.conf 5 ,
 .Xr extsmail.externals 5 ,

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -1491,8 +1491,14 @@ static void check_externals(const char *file)
 
 static void usage(int rtn_code)
 {
-    fprintf(stderr, "Usage: %s [-m <batch|daemon>] [-t <conf>]\n", __progname);
+    fprintf(stderr, "Usage: %s [-hv] [-m <batch|daemon>] [-t <conf>]\n", __progname);
     exit(rtn_code);
+}
+
+
+static void version()
+{
+  puts(PACKAGE_NAME " " PACKAGE_VERSION);
 }
 
 
@@ -1500,7 +1506,7 @@ int main(int argc, char** argv)
 {
     Mode mode = BATCH_MODE;
     int ch;
-    while ((ch = getopt(argc, argv, "hm:t:")) != -1) {
+    while ((ch = getopt(argc, argv, "hm:t:v")) != -1) {
         switch (ch) {
             case 'm':
                 if (strcmp(optarg, "batch") == 0)
@@ -1515,6 +1521,10 @@ int main(int argc, char** argv)
                 break;
             case 't':
                 check_externals(optarg);
+                exit(0);
+                break;
+            case 'v':
+                version();
                 exit(0);
                 break;
             default:


### PR DESCRIPTION
Rationale:
1. UNIX programs have a command line option to display their [version](https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html)
2. Even if -h exits successfully when invoked, printing usage to stderr prevents CI tests from succeeding (for example, [Debian CI](https://ci.debian.net/data/packages/unstable/amd64/e/extsmail/latest-autopkgtest/log.gz) considers those messages as errors)
