### PR TITLE
Define _POSIX_C_SOURCE on GNU kernels.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_CHECK_HEADERS(sys/inotify.h, [AC_DEFINE(HAVE_INOTIFY)])
 # fileno (Linux)
 
 case `uname -s` in
-  Linux* ) CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=2";;
+  Linux*|GNU* ) CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=2";;
 esac
 
 # set hardening flags


### PR DESCRIPTION
I suspect this is the reason for [this complaint](https://qa.debian.org/bls/packages/e/extsmail.html).