### PR TITLE
Add -Werror, -pedantic-errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_GNU_SOURCE
 # Function / feature checks
 #
 
-CFLAGS="$CFLAGS -std=c99 -Wall -pedantic -Wextra"
+CFLAGS="$CFLAGS -std=c99 -Wall -pedantic -Wextra -Werror -pedantic-errors"
 
 # kqueue (*BSD)
 


### PR DESCRIPTION
Given the build results available [here](https://buildd.debian.org/status/package.php?p=extsmail), I feel pretty confident adding these options.
Successfully tested on OpenBSD-6.4 and Debian/sid.