### PR TITLE
Add pledge(2) support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,12 @@ AC_GNU_SOURCE
 
 CFLAGS="$CFLAGS -std=c99 -Wall -pedantic -Wextra -Werror -pedantic-errors"
 
+# pledge
+
+AH_TEMPLATE(HAVE_PLEDGE,
+	      [Define if your platform has the pledge(2) syscall.])
+AC_CHECK_HEADERS(sys/pledge.h, [AC_DEFINE(HAVE_PLEDGE)])
+
 # kqueue (*BSD)
 
 AH_TEMPLATE(HAVE_KQUEUE,

--- a/extsmail.c
+++ b/extsmail.c
@@ -45,6 +45,11 @@ extern char* __progname;
 
 int main(int argc, char** argv)
 {
+#ifdef HAVE_PLEDGE
+    if (pledge("stdio rpath wpath cpath flock getpw", NULL) == -1)
+        err(EXIT_FAILURE, "pledge");
+#endif
+
     Conf *conf = read_conf();
 
     // Check that everything to do with the spool dir is OK.

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -1510,6 +1510,11 @@ static void version()
 
 int main(int argc, char** argv)
 {
+#ifdef HAVE_PLEDGE
+    if (pledge("stdio rpath wpath cpath flock getpw proc exec", NULL) == -1)
+        err(EXIT_FAILURE, "pledge");
+#endif
+
     Mode mode = BATCH_MODE;
     int ch;
     while ((ch = getopt(argc, argv, "hm:t:v")) != -1) {


### PR DESCRIPTION
Strange, Travis CI fails... Compiles here with `clang version 7.0.1-9 (tags/RELEASE_701/final)` (and no idea what Yacc version is used in Travis):

```
(...)
clang version
clang version 7.0.0 (tags/RELEASE_700/final)
(...)
$ make
yacc -p yyc -d -b conf_parser conf_parser.y
clang -g -O2 -std=c99 -Wall -pedantic -Wextra -Werror -pedantic-errors -D_POSIX_C_SOURCE=2   -c -o conf_parser.tab.o conf_parser.tab.c
lex -Pyyc -oconf_tokenizer.c conf_tokenizer.l
clang -g -O2 -std=c99 -Wall -pedantic -Wextra -Werror -pedantic-errors -D_POSIX_C_SOURCE=2   -c -o conf_tokenizer.o conf_tokenizer.c
conf_tokenizer.c:1184:44: error: comparison of integers of different signs:
      'int' and 'yy_size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
  ...(int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
<builtin>: recipe for target 'conf_tokenizer.o' failed
make: *** [conf_tokenizer.o] Error 1
The command "make" exited with 2.
```

Otherwise, works fine (OpenBSD 6.5).