### PR TITLE
Child processes mustn't process data

### DIFF
--- a/extsmaild.c
+++ b/extsmaild.c
@@ -1151,7 +1151,9 @@ static bool try_groups(Conf *conf, Status *status, const char *msg_path, int fd)
             goto fail;
         }
         else if (pid == 0) {
-            // Child / sendmail process.
+            // Child / sendmail process. Any errors in this branch should cause
+            // the child process to exit rather than try to continue executing
+            // as if it was the parent process.
 
             close(STDOUT_FILENO);
             if (dup2(pipeto[0], STDIN_FILENO) == -1 || dup2(pipefrom[1],
@@ -1161,7 +1163,7 @@ static bool try_groups(Conf *conf, Status *status, const char *msg_path, int fd)
                 close(pipefrom[0]);
                 close(pipefrom[1]);
                 syslog(LOG_CRIT, "try_groups: dup2: %s", strerror (errno));
-                goto fail;
+                exit(1);
             }
             close(pipeto[0]);
             close(pipeto[1]);
@@ -1184,7 +1186,7 @@ static bool try_groups(Conf *conf, Status *status, const char *msg_path, int fd)
             execvp(cur_ext->sendmail_argv[0], (char **const) sub_argv);
             free(sub_argv);
             syslog(LOG_CRIT, "try_groups: execvp: %s", strerror (errno));
-            goto fail;
+            exit(1);
         }
         else {
             // Parent process.


### PR DESCRIPTION
When we've found a match, we fork, and exec the command the user has specified. If there are any problems in that process, we sometimes called `goto next` -- i.e. the child process executed as if it was the parent process. The good news is that this could never cause mail to be lost (at worst it would be sent more than once), but it could cause a fork bomb of sorts. The correct behaviour is for the child process to `exit()` on any error.