### PR TITLE
Keep sending messages

### DIFF
--- a/extsmaild.c
+++ b/extsmaild.c
@@ -449,7 +449,7 @@ static bool cycle(Conf *conf, Group *groups, Status *status)
     }
 
     bool all_sent = true;
-    bool tried_once = false; // Make sure we read every entry at least once.
+    bool tried_once = false; // Make sure we've tried at least one file.
     int num_successes = 0;   // How many messages have been successfully sent.
     while (1) {
         char *msg_path = NULL;

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -465,32 +465,13 @@ static bool cycle(Conf *conf, Group *groups, Status *status)
                         // so we can now be sure that we've read everything.
                         break;
                     }
-                    else if (!tried_once) {
-                        // We haven't read any entries, but we've already read
-                        // past the end of the directory. We reset the directory
-                        // read to the start and carry on as if we'd always
-                        // intended to start from the beginning of the
-                        // directory.
-                        start_spool_loc = status->spool_loc = 0;
-                    }
-                    else if (start_spool_loc > spool_loc) {
-                        // Entries have been removed from the directory during
-                        // the cycle (probably because we've sent messages
-                        // successfully, but maybe because of user interaction).
-                        // We reset the directory read to the start, in case
-                        // files were present earlier in the readdir that we
-                        // never tried, or new files have been added in the
-                        // interim.
-                        start_spool_loc = status->spool_loc = 0;
-                        tried_once = false;
-                    }
-
-                    // There could be entries between seekdir(0) and
-                    // seekdir(status->spool_loc) that we haven't yet tried to
-                    // send, so rewind to make sure we have a chance of trying
-                    // then.
+                    // This cycle started part way through, possibly because
+                    // some messages are stuck, or files were deleted. Reset
+                    // the directory read to the beginning and try cycling
+                    // through the whole thing again.
                     rewinddir(dirp);
-                    spool_loc = 0;
+                    spool_loc = 0 = start_spool_loc = status->spool_loc = 0;
+                    tried_once = false;
                     continue;
                 }
                 else

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -577,14 +577,11 @@ next_try:
             sleep(1);
         }
 
+        free(msg_path);
         if (conf->mode == DAEMON_MODE && !all_sent) {
             status->spool_loc = spool_loc + 1;
-            free(msg_path);
             break;
         }
-
-        if (msg_path)
-            free(msg_path);
 
         if (conf->mode == DAEMON_MODE) {
             if (tried_once && spool_loc == start_spool_loc) {

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -561,10 +561,6 @@ next_try:
         free(msg_path);
         if (conf->mode == DAEMON_MODE) {
             status->spool_loc += 1;
-            if (!all_sent) {
-                break;
-            }
-
             if (tried_once && start_spool_loc == status->spool_loc) {
                 // We've read all the directory entries at least once.
                 break;

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -503,9 +503,10 @@ static bool cycle(Conf *conf, Group *groups, Status *status)
         }
 
         // The entries "." and ".." are, fairly obviously, not messages.
-
-        if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
-            goto next_msg;
+        if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
+            spool_loc += 1;
+            continue;
+        }
 
         if (asprintf(&msg_path, "%s%s%s%s%s", conf->spool_dir, DIR_SEP,
           MSGS_DIR, DIR_SEP, dp->d_name) == -1) {
@@ -582,7 +583,6 @@ next_try:
             break;
         }
 
-next_msg:
         if (msg_path)
             free(msg_path);
 


### PR DESCRIPTION
This PR tries to ensure that extsmail keeps sending messages even if one or more is stuck (e.g. because it's an empty file).

@oliv3 I *think* this might fix https://github.com/ltratt/extsmail/issues/45. The logic for "retry sending often but not too much" was too complex and I can see 1 definite bug, 1 probable bug, and 1 who-knows-if-it's-a-bug. I've tried simplifying it quite a bit. I think we should keep iterating this PR until it solves the problem you see.