### PR TITLE
Keep sending messages even in the face of failure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,11 @@ esac
 
 LDFLAGS="$LDFLAGS -Wl,-z,relro,-z,now"
 
+# arc4random_uniform
+
+AH_TEMPLATE(HAVE_ARC4RANDOM_UNIFORM, [Define if your platform has the arc4random_uniform function.])
+AC_CHECK_FUNC(arc4random_uniform, [AC_DEFINE(HAVE_ARC4RANDOM_UNIFORM)])
+
 # strtonum
 
 AH_TEMPLATE(HAVE_STRTONUM, [Define if your platform has the strtonum function.])

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -449,7 +449,7 @@ static bool cycle(Conf *conf, Group *groups, Status *status)
     }
 
     bool all_sent = true;
-    bool tried_once = false; // Make sure we read every entry at least once.
+    bool tried_once = false; // Make sure we've tried at least one file.
     int num_successes = 0;   // How many messages have been successfully sent.
     while (1) {
         char *msg_path = NULL;

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -577,14 +577,11 @@ next_try:
             sleep(1);
         }
 
+        free(msg_path);
         if (conf->mode == DAEMON_MODE && !all_sent) {
             status->spool_loc = spool_loc + 1;
-            free(msg_path);
             break;
         }
-
-        if (msg_path)
-            free(msg_path);
 
         if (conf->mode == DAEMON_MODE) {
             if (tried_once && spool_loc == start_spool_loc) {

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -408,7 +408,11 @@ static int cycle(Conf *conf, Group *groups, Status *status)
                 num_entries += 1;
             }
             rewinddir(dirp);
+#ifdef HAVE_ARC4RANDOM_UNIFORM
             uint32_t skip = arc4random_uniform(num_entries);
+#else
+            uint32_t skip = ((uint32_t) rand()) % num_entries;
+#endif
             for (uint32_t i = 0; i < skip; i += 1) {
                 readdir(dirp);
             }

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -503,9 +503,10 @@ static bool cycle(Conf *conf, Group *groups, Status *status)
         }
 
         // The entries "." and ".." are, fairly obviously, not messages.
-
-        if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
-            goto next_msg;
+        if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) {
+            spool_loc += 1;
+            continue;
+        }
 
         if (asprintf(&msg_path, "%s%s%s%s%s", conf->spool_dir, DIR_SEP,
           MSGS_DIR, DIR_SEP, dp->d_name) == -1) {
@@ -582,7 +583,6 @@ next_try:
             break;
         }
 
-next_msg:
         if (msg_path)
             free(msg_path);
 


### PR DESCRIPTION
Before this PR, never-sendable messages could cause extsmaild to get stuck in the queue. This PR solves that issue, and also makes extsmaild try harder to send messages quickly in the face of failure. The basic idea is that as long as *some* messages are being sent successfully, we don't allow the failure to send other messages impose long delays. Only if the queue gets to the point where the remaining messages are all (currently) unsuccessful do we start to increment the sending delay.

Hopefully fixes #45 -- @oliv3, comments and testing are welcome! This is a fairly significant change, so I will be running this for quite a while before it goes into a new release.