### PR TITLE
Check for <bsd/stdlib.h> on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,17 +65,19 @@ AC_CHECK_HEADERS(sys/inotify.h, [AC_DEFINE(HAVE_INOTIFY)])
 # fileno (Linux)
 
 case `uname -s` in
-  Linux*|GNU* ) CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=2";;
+  Linux*|GNU* )
+   CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=2"
+   LDFLAGS="$LDFLAGS -lbsd"
+   # arc4random_uniform
+   AH_TEMPLATE(HAVE_BSD_STDLIB_H,
+     [Define if your platform has the <bsd/stdlib.h> header file.])
+   AC_CHECK_HEADERS(bsd/stdlib.h, [AC_DEFINE(HAVE_BSD_STDLIB_H)])
+   ;;
 esac
 
 # set hardening flags
 
 LDFLAGS="$LDFLAGS -Wl,-z,relro,-z,now"
-
-# arc4random_uniform
-
-AH_TEMPLATE(HAVE_ARC4RANDOM_UNIFORM, [Define if your platform has the arc4random_uniform function.])
-AC_CHECK_FUNC(arc4random_uniform, [AC_DEFINE(HAVE_ARC4RANDOM_UNIFORM)])
 
 # strtonum
 

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -53,6 +53,10 @@
 #include "compat/strtonum.h"
 #endif
 
+#ifdef HAVE_BSD_STDLIB_H
+#include <bsd/stdlib.h>
+#endif
+
 #include "conf.h"
 #include "common.h"
 #include "externals.h"
@@ -408,11 +412,7 @@ static int cycle(Conf *conf, Group *groups, Status *status)
                 num_entries += 1;
             }
             rewinddir(dirp);
-#ifdef HAVE_ARC4RANDOM_UNIFORM
             uint32_t skip = arc4random_uniform(num_entries);
-#else
-            uint32_t skip = ((uint32_t) rand()) % num_entries;
-#endif
             for (uint32_t i = 0; i < skip; i += 1) {
                 readdir(dirp);
             }


### PR DESCRIPTION
Linux *does* have an `arc4random_uniform()` function.

- Check for `<bsd/stdlib.h>` where it is declared
- Link against `-lbsd`