### PR TITLE
Deal better with child processes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,11 @@ externals_tokenizer.c: externals_tokenizer.l
 	${LEX} -Pyye -oexternals_tokenizer.c externals_tokenizer.l
 
 
+test: all
+	@test @JOT@ || sh -c 'echo "'jot' needed to run test suite" 2>&1 ; exit 1'
+	cd tests && ./run.sh
+
+
 install: all
 	install -d ${DESTDIR}${bindir}
 	install -c -m 555 extsmail ${DESTDIR}${bindir}

--- a/common.h
+++ b/common.h
@@ -24,7 +24,7 @@
 
 #define VERSION1_ID "v1"
 
-Conf *read_conf();
+Conf *read_conf(char *);
 void free_conf(Conf *);
 bool check_spool_dir(Conf *);
 

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,9 @@ case `uname -s` in
    AH_TEMPLATE(HAVE_BSD_STDLIB_H,
      [Define if your platform has the <bsd/stdlib.h> header file.])
    AC_CHECK_HEADERS(bsd/stdlib.h, [AC_DEFINE(HAVE_BSD_STDLIB_H)])
+   AH_TEMPLATE(HAVE_BSD_STRING_H,
+     [Define if your platform has the <bsd/string.h> header file.])
+   AC_CHECK_HEADERS(bsd/string.h, [AC_DEFINE(HAVE_BSD_STRING_H)])
    ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,18 @@ case $flex_version in
         ;;
 esac
 
+
+################################################################################
+# Testing feature checks
+#
+
+ AC_CHECK_PROGS(JOT, jot, false)
+ if test "${JOT}" = "false"; then
+     AC_MSG_WARN([jot not installed: cannot run test suite.])
+     unset JOT
+ fi
+
+
 ################################################################################
 # Output
 #

--- a/extsmail.c
+++ b/extsmail.c
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
         err(EXIT_FAILURE, "pledge");
 #endif
 
-    Conf *conf = read_conf();
+    Conf *conf = read_conf(NULL);
 
     // Check that everything to do with the spool dir is OK.
 

--- a/extsmaild.1
+++ b/extsmaild.1
@@ -26,6 +26,7 @@
 .Sh SYNOPSIS
 .Nm extsmaild
 .Op Fl c Ar config-file
+.Op Fl e Ar externals-file
 .Op Fl m Ar mode
 .Op Fl t
 .Op Fl v

--- a/extsmaild.1
+++ b/extsmaild.1
@@ -25,6 +25,7 @@
 .Nd robust sending of e-mail to external commands
 .Sh SYNOPSIS
 .Nm extsmaild
+.Op Fl c Ar config-file
 .Op Fl m Ar mode
 .Op Fl t
 .Op Fl v

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -35,6 +35,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/extsmaild.c
+++ b/extsmaild.c
@@ -1425,7 +1425,7 @@ static void check_externals(const char *file)
 
 static void usage(int rtn_code)
 {
-    fprintf(stderr, "Usage: %s [-hv] [-m <batch|daemon>] [-t <conf>]\n", __progname);
+    fprintf(stderr, "Usage: %s [-c <config-file>] [-hv] [-m <batch|daemon>] [-t]\n", __progname);
     exit(rtn_code);
 }
 
@@ -1445,8 +1445,17 @@ int main(int argc, char** argv)
 
     Mode mode = BATCH_MODE;
     int ch;
-    while ((ch = getopt(argc, argv, "hm:t:v")) != -1) {
+    char *conf_path = NULL;
+    while ((ch = getopt(argc, argv, "c:hm:t:v")) != -1) {
         switch (ch) {
+            case 'c':
+                if (conf_path)
+                    usage(1);
+                conf_path = malloc(strlen(optarg) + 1);
+                if (conf_path == NULL)
+                    errx(1, "main: unable to allocate memory");
+                strcpy(conf_path, optarg);
+                break;
             case 'm':
                 if (strcmp(optarg, "batch") == 0)
                     mode = BATCH_MODE;
@@ -1471,7 +1480,7 @@ int main(int argc, char** argv)
         }
     }
 
-    Conf *conf = read_conf();
+    Conf *conf = read_conf(conf_path);
 
     read_externals();
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -37,7 +37,7 @@ cat << EOF > $t/extsmail.conf
 spool_dir = "$t/spool_dir/"
 EOF
 
-echo "===> test_stderr_write"
+echo -n "test_stderr_write... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -49,11 +49,12 @@ chown :`id -g` $t/externals
 chmod 700 $t/spool_dir
 chmod 700 $t/spool_dir/msgs
 cc -Wall -o $t/test_stderr_write test_stderr_write.c
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "extsmaild.*test$"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "extsmaild.*test$"
 jot 10000 >> $t/spool_dir/msgs/1
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "extsmaild.*test$"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "extsmaild.*test$"
+echo OK
 
-echo "===> test_read_all_fail"
+echo -n "test_read_all_fail... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -63,9 +64,10 @@ group {
 EOF
 chown :`id -g` $t/externals
 cc -Wall -o $t/test_read_all_fail test_read_all_fail.c
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: Received error 1 when executing"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "^extsmaild: test: Received error 1 when executing"
+echo OK
 
-echo "===> read_all_stall"
+echo -n "read_all_stall... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -75,12 +77,12 @@ group {
 EOF
 chown :`id -g` $t/externals
 cc -Wall -o $t/test_read_all_stall test_read_all_stall.c
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: Timeout when executing"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "^extsmaild: test: Timeout when executing"
+echo OK
 
-echo "===> read_all_stall (kill by signal)"
+echo -n "read_all_stall (kill by signal)... "
 # The next test is potentially flaky as it relies on timing.
 t2=`mktemp`
-echo $t2
 ../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>$t2 &
 pid=$!
 sleep 3
@@ -90,10 +92,11 @@ pkill -SIGKILL -P $pid -f test_read_all_stall
 wait $pid || true
 # For reasons I don't understand, Linux can report the wrong signal number as
 # being the cause of the signal's termination.
-grep "extsmaild: test: Received signal 9" $t2
+grep -q "extsmaild: test: Received signal 9" $t2
 rm $t2
+echo OK
 
-echo "===> test_too_slow"
+echo -n "test_too_slow... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -103,9 +106,10 @@ group {
 EOF
 chown :`id -g` $t/externals
 cc -Wall -o $t/test_too_slow test_too_slow.c
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: .*Timeout$"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "^extsmaild: test: .*Timeout$"
+echo OK
 
-echo "===> test_too_slow2"
+echo -n "test_too_slow2... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -115,9 +119,10 @@ group {
 EOF
 chown :`id -g` $t/externals
 cc -Wall -o $t/test_too_slow2 test_too_slow2.c
-../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: .*Timeout$"
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "^extsmaild: test: .*Timeout$"
+echo OK
 
-echo "===> test_slow_read"
+echo -n "test_slow_read... "
 cat << EOF > $t/externals
 group {
     external test {
@@ -128,5 +133,6 @@ EOF
 chown :`id -g` $t/externals
 cc -Wall -o $t/test_slow_read test_slow_read.c
 ../extsmaild -m batch -c $t/extsmail.conf -e $t/externals
+echo OK
 
 rm -rf $t

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,116 @@
+#! /bin/sh
+
+set -euf
+
+t=`mktemp -d`
+
+mkdir -p $t/spool_dir/msgs
+cat << EOF > $t/spool_dir/msgs/1
+v1
+6
+4
+-oem
+3
+-oi
+2
+-f
+17
+email@example.com
+2
+--
+17
+email@example.com
+Date: Sat, 17 Sep 2022 08:55:41 +0100
+From: email@example.com
+To: email@example.com
+Subject: test
+Message-ID: <20220917075541.j42vuhpkgoc7qamo@example.com>
+User-Agent: mutt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=us-ascii
+Content-Disposition: inline
+
+test
+EOF
+
+cat << EOF > $t/extsmail.conf
+spool_dir = "$t/spool_dir/"
+EOF
+
+echo "===> test_stderr_write"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_stderr_write"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+chmod 700 $t/spool_dir
+chmod 700 $t/spool_dir/msgs
+cc -Wall -o $t/test_stderr_write test_stderr_write.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "extsmaild.*test$"
+jot 10000 >> $t/spool_dir/msgs/1
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "extsmaild.*test$"
+
+echo "===> test_read_all_fail"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_read_all_fail"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/test_read_all_fail test_read_all_fail.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: Received error 1 when executing"
+
+echo "===> read_all_stall"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/read_all_stall"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/read_all_stall test_read_all_stall.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: Timeout when executing"
+
+echo "===> test_too_slow"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_too_slow"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/test_too_slow test_too_slow.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: .*Timeout$"
+
+echo "===> test_too_slow2"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_too_slow2"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/test_too_slow2 test_too_slow2.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep "^extsmaild: test: .*Timeout$"
+
+echo "===> test_slow_read"
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_slow_read"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/test_slow_read test_slow_read.c
+../extsmaild -m batch -c $t/extsmail.conf -e $t/externals
+
+rm -rf $t

--- a/tests/test_read_all_fail.c
+++ b/tests/test_read_all_fail.c
@@ -1,0 +1,16 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    char buf[4096];
+    while (true) {
+	int rtn = read(STDIN_FILENO, buf, 4096);
+	if (rtn == 0)
+	    break;
+	else if (rtn == -1)
+	    err(1, "Failed to read");
+    }
+    return 1;
+}

--- a/tests/test_read_all_stall.c
+++ b/tests/test_read_all_stall.c
@@ -1,0 +1,19 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    char buf[4096];
+    while (true) {
+	int rtn = read(STDIN_FILENO, buf, 4096);
+	if (rtn == 0)
+	    break;
+	else if (rtn == -1)
+	    err(1, "Failed to read");
+    }
+    close(STDIN_FILENO);
+    close(STDERR_FILENO);
+    sleep(90);
+    return 0;
+}

--- a/tests/test_slow_read.c
+++ b/tests/test_slow_read.c
@@ -1,0 +1,19 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    sleep(5);
+    char buf[4096];
+    while (true) {
+	int rtn = read(STDIN_FILENO, buf, 4096);
+	if (rtn == 0)
+	    break;
+	else if (rtn == -1)
+	    err(1, "Failed to read");
+	sleep(1);
+    }
+    sleep(5);
+    return 0;
+}

--- a/tests/test_stderr_write.c
+++ b/tests/test_stderr_write.c
@@ -1,0 +1,11 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    close(STDIN_FILENO);
+    close(STDOUT_FILENO);
+    sleep(1);
+    dprintf(STDERR_FILENO, "test");
+    return 1;
+}

--- a/tests/test_too_slow.c
+++ b/tests/test_too_slow.c
@@ -1,0 +1,17 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    char buf[4096];
+    while (true) {
+	int rtn = read(STDIN_FILENO, buf, 4096);
+	if (rtn == 0)
+	    break;
+	else if (rtn == -1)
+	    err(1, "Failed to read");
+    }
+    sleep(90);
+    return 0;
+}

--- a/tests/test_too_slow2.c
+++ b/tests/test_too_slow2.c
@@ -1,0 +1,17 @@
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    sleep(90);
+    char buf[4096];
+    while (true) {
+	int rtn = read(STDIN_FILENO, buf, 4096);
+	if (rtn == 0)
+	    break;
+	else if (rtn == -1)
+	    err(1, "Failed to read");
+    }
+    return 0;
+}


### PR DESCRIPTION
This PR deals with https://github.com/ltratt/extsmail/issues/54 and more. After adding switches (`-c` and `-e` in https://github.com/ltratt/extsmail/commit/e7ed530e660d4289fa375e93aefecfd72a54dc8f and https://github.com/ltratt/extsmail/commit/b384d969fef8853f4efae30482d5c92dfdd50bb6 respectively), the fix for #54 (and more) is in https://github.com/ltratt/extsmail/commit/17bc30deb3032eaa7d964b520af1cb9fbd8959f4. That highlighted a second, sort-of related, problem which I've fixed in https://github.com/ltratt/extsmail/commit/fa67e874aa4f7b11e1d89335e25647d170f30ec1.

This PR is, in total, a hefty change to how extsmaild deals with child processes. I have added a test suite which checks that most of the major plausible outcomes are tested -- the test suite was vital in giving me adequate confidence to raise this PR. The test suite showed unexpected differences on OpenBSD and Linux -- it now passes on both platforms.

However, this is still a big change. @stephenrkell I'd be grateful if you're able to test whether this fixes your problem (which I think is equivalent to the test in `test_stderr_write`). @oliv3 I'd also be grateful if you're able to run this for a little while to see if it works for you. If we're all happy with this after a couple of weeks of testing, I think we can consider merging it into master.