### PR TITLE
Rework poll().

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,6 +54,20 @@ jot 10000 >> $t/spool_dir/msgs/1
 ../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | grep -q "extsmaild.*test$"
 echo OK
 
+echo -n "test_stderr_big_write... "
+cat << EOF > $t/externals
+group {
+    external test {
+        sendmail = "$t/test_stderr_big_write"
+    }
+}
+EOF
+chown :`id -g` $t/externals
+cc -Wall -o $t/test_stderr_big_write test_stderr_big_write.c
+sz=$(../extsmaild -m batch -c $t/extsmail.conf -e $t/externals 2>&1 | wc -c)
+test $sz -gt 4096
+echo OK
+
 echo -n "test_read_all_fail... "
 cat << EOF > $t/externals
 group {

--- a/tests/test_stderr_big_write.c
+++ b/tests/test_stderr_big_write.c
@@ -1,0 +1,18 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+// This test is fragile, because some syslog implementations truncate messages
+// at 1KiB.
+
+// This value must be bigger than STDERR_BUF_ALLOC in extsmaild.c.
+#define WRITE_SIZE 4096
+
+int main() {
+    char *buf = malloc(WRITE_SIZE);
+    for (size_t i = 0; i < WRITE_SIZE; i++)
+	buf[i] = 'a';
+    write(STDERR_FILENO, buf, WRITE_SIZE);
+    return 1;
+}


### PR DESCRIPTION
This commit fixes at least two problems:

  1. We didn't keep `read()`ing stderr after receiving `POLLIN` which meant that we could truncate stderr if we also received `POLLHUP` The `test_stderr_big_write` test failed before the fix in this commit.

  2. We could potentially have closed stderr twice since `POLLIN` and `POLLHUP` are not mutually exclusive. I couldn't find a test which predictably triggers this, but it was clearly a possibility.

While fixing these, it also made sense to clean up the code a bit, as I am now rather more familiar with `poll()` and how to handle it than I was before. I am not, however, foolish enough to pretend that I understand everything that could happen around `poll`!