### PR TITLE
Deal with `poll` returning "timeout" correctly.

### DIFF
--- a/extsmaild.c
+++ b/extsmaild.c
@@ -934,14 +934,16 @@ bool write_to_child(int fd, int cstderr_fd, int *cstdin_fd,
 
         time_t tout = (MAX_POLL_NO_SEND - (time(NULL) - last_io_time)) * 1000;
         if (tout <= 0) {
-            *errmsgbuf_used = strlcpy(*errmsgbuf, "Timeout", stderrbuf_alloc);
-            goto err;
+            goto timeout;
         }
 
-        if (poll(fds, 3, tout) == -1) {
+        int poll_rtn = poll(fds, 3, tout);
+        if (poll_rtn == -1) {
             if (errno == EINTR)
                 continue;
             goto err;
+        } else if (poll_rtn == 0) {
+            goto timeout;
         }
 
         // Write data to the child process (if appropriate).
@@ -1019,6 +1021,9 @@ bool write_to_child(int fd, int cstderr_fd, int *cstdin_fd,
             }
         }
     }
+
+timeout:
+    *errmsgbuf_used = strlcpy(*errmsgbuf, "Timeout", stderrbuf_alloc);
 
 err:
     // stderr messages sometimes have random newline chars at the end of line - this loop


### PR DESCRIPTION
There's no guarantee that when `poll` returns 0 `fds` has meaningful content (that's not to say it _doesn't_ have meaningful content: it's just not documented AFAIK). Even though we apply our own timeout, we might misinterpret `fds` in ways that are platform dependent.